### PR TITLE
fix(netlify): set Node runtime to 20 for Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "20"
 
 [build]
   publish = "dist"


### PR DESCRIPTION
### Motivation
- Netlify production builds were failing with an `ERR_REQUIRE_ESM` error when loading the Vite config via `unplugin-icons` / `@antfu/install-pkg`, which is symptomatic of Node/CommonJS vs ESM runtime incompatibility on older Node versions.

### Description
- Updated `netlify.toml` to set `NODE_VERSION` from `16` to `20` so Netlify uses a modern Node LTS runtime compatible with the ESM-based dependencies, with no application code changes.

### Testing
- Attempted to run `pnpm run build` in this environment but the run was blocked by Corepack failing to download `pnpm` (network/proxy error), so an automated build could not be completed here; the change specifically targets the runtime mismatch shown in the Netlify build logs and should be validated by triggering a new Netlify deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85ce3a2c8832b91ade52437bc936c)