### PR TITLE
Bump Netlify Node to 20 and fix photo data structure in PicsPage.vue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "20"
 
 [build]
   publish = "dist"

--- a/src/components/PicsPage.vue
+++ b/src/components/PicsPage.vue
@@ -93,9 +93,6 @@ export default {
             },            
           ]
         },
-          ]
-        },
-      ],
       highlightPosition: 0,
     };
   },


### PR DESCRIPTION
### Motivation
- Move the Netlify build runtime to a newer Node version and fix a malformed photos data structure in the PicsPage component so the gallery initializes and renders correctly.

### Description
- Update `NODE_VERSION` from `"16"` to `"20"` in `netlify.toml`.
- Remove extraneous/incorrect closing array/object entries in `src/components/PicsPage.vue` to correct the `images`/`photos` data shape and re-enable the component's state (`highlightPosition`, `selectedYear`, etc.).
- Add a trailing newline to `netlify.toml` (formatting).

### Testing
- Ran the production build with `pnpm run build`, which completed successfully.
- Verified the Vue component compiles as part of the build (no compile errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85ce3a2c8832b91ade52437bc936c)