### PR TITLE
Bump Netlify Node to 20 and fix PicsPage photos array structure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "20"
 
 [build]
   publish = "dist"

--- a/src/components/PicsPage.vue
+++ b/src/components/PicsPage.vue
@@ -93,8 +93,6 @@ export default {
             },            
           ]
         },
-          ]
-        },
       ],
       highlightPosition: 0,
     };


### PR DESCRIPTION
### Motivation
- Ensure the deployed site uses a supported Node runtime (Node 20) and fix a malformed photos data structure in the Pics page that could produce compile/runtime errors.

### Description
- Update `netlify.toml` to set `NODE_VERSION` to `20` and correct `src/components/PicsPage.vue` by removing extraneous closing brackets and realigning the `images`/`photos` array so the component's data is well-formed.

### Testing
- Ran the production build with `pnpm run build` locally and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85ce3a2c8832b91ade52437bc936c)